### PR TITLE
allow quoted command paths in windows cmd

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "io.github.kscripting"
-version = "0.5.0"
+version = "0.5.1"
 
 sourceSets {
     create("integration") {

--- a/src/main/kotlin/io/github/kscripting/shell/ShellExecutor.kt
+++ b/src/main/kotlin/io/github/kscripting/shell/ShellExecutor.kt
@@ -61,10 +61,12 @@ object ShellExecutor {
     ): ProcessResult {
         //NOTE: cmd is an argument to shell (bash/cmd), so it should stay not split by whitespace as a single string
         if (osType == OsType.WINDOWS) {
+            // if the first character in args in `cmd /c <args>` is a quote, cmd will remove it as well as the
+            // last quote character within args before processing the term, which removes our quotes.
             return ProcessRunner.runProcess(
                 "cmd",
                 "/c",
-                command,
+                " $command",
                 workingDirectory = workingDirectory,
                 envAdjuster = envAdjuster,
                 waitTimeMinutes = waitTimeMinutes,


### PR DESCRIPTION
Prevents https://github.com/kscripting/kscript/issues/397#issue-1650562741

Without this change, quoting the command under windows becomes difficult, because `cmd` will remove the quote if it is the first character in the string - we prevent this behavior by just adding a single space character. Additional spaces do not influence `cmd` arguments.

Incremented version to 0.5.1 according to semver (change is source compatible).